### PR TITLE
Add DogStatsd sink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Swap files
+*.swp

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -1,0 +1,101 @@
+package metrics
+
+import (
+	"fmt"
+	"github.com/Datadog/datadog-go/statsd"
+	"strings"
+)
+
+// HostnameGetter is a generic function to retrieve a hostname
+type HostnameGetter func() string
+
+// DogStatsdSink provides a MetricSink that can be used
+// with a dogstatsd server. It utilizes the Dogstatsd client at github.com/Datadog/datadog-go/statsd
+type DogStatsdSink struct {
+	client                *statsd.Client
+	hostnameGetter        HostnameGetter
+	enableHostnameTagging bool
+}
+
+func getHostname() string {
+	conf, _ := GetConfig()
+	return conf.HostName
+}
+
+// NewDogStatsdSink is used to create a new DogStatsdSink
+func NewDogStatsdSink(addr string, tags []string, tagWithHostname bool) (*DogStatsdSink, error) {
+	client, err := statsd.New(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	client.Tags = tags
+	sink := &DogStatsdSink{
+		client:                client,
+		hostnameGetter:        getHostname,
+		enableHostnameTagging: tagWithHostname,
+	}
+	return sink, nil
+}
+
+func (s *DogStatsdSink) flattenKey(parts []string) string {
+	joined := strings.Join(parts, ".")
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ':':
+			fallthrough
+		case ' ':
+			return '_'
+		default:
+			return r
+		}
+	}, joined)
+}
+
+func (s *DogStatsdSink) parseKey(key []string) ([]string, []string) {
+	var tags []string
+	hostName := s.hostnameGetter()
+
+	//Splice the hostname out of the key
+	for i, el := range key {
+		if el == hostName {
+			key = append(key[:i], key[i+1:]...)
+		}
+	}
+
+	if s.enableHostnameTagging {
+		tags = append(tags, fmt.Sprintf("host:%s", hostName))
+	}
+	return key, tags
+}
+
+// Implementation of methods in the MetricSink interface
+
+func (s *DogStatsdSink) SetGauge(key []string, val float32) {
+	key, tags := s.parseKey(key)
+	flatKey := s.flattenKey(key)
+
+	rate := 1.0
+	s.client.Gauge(flatKey, float64(val), tags, rate)
+}
+
+func (s *DogStatsdSink) IncrCounter(key []string, val float32) {
+	key, tags := s.parseKey(key)
+	flatKey := s.flattenKey(key)
+
+	rate := 1.0
+	s.client.Count(flatKey, int64(val), tags, rate)
+}
+
+// EmitKey is not implemented since DogStatsd does not provide a metric type that holds an
+// arbitrary number of values
+func (s *DogStatsdSink) EmitKey(key []string, val float32) {
+}
+
+func (s *DogStatsdSink) AddSample(key []string, val float32) {
+	key, tags := s.parseKey(key)
+	flatKey := s.flattenKey(key)
+
+	rate := 1.0
+	s.client.TimeInMilliseconds(flatKey, float64(val), tags, rate)
+}

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+)
+
+var EmptyTags []string
+
+const (
+	DogStatsdAddr    = "127.0.0.1:7254"
+	HostnameEnabled  = true
+	HostnameDisabled = false
+	TestHostname     = "test_hostname"
+)
+
+func MockGetHostname() string {
+	return TestHostname
+}
+
+var ParseKeyTests = []struct {
+	KeyToParse            []string
+	Tags                  []string
+	EnableHostnameTagging bool
+	ExpectedKey           []string
+	ExpectedTags          []string
+}{
+	{[]string{"a", MockGetHostname(), "b", "c"}, EmptyTags, HostnameDisabled, []string{"a", "b", "c"}, EmptyTags},
+	{[]string{"a", "b", "c"}, EmptyTags, HostnameDisabled, []string{"a", "b", "c"}, EmptyTags},
+	{[]string{"a", "b", "c"}, EmptyTags, HostnameEnabled, []string{"a", "b", "c"}, []string{fmt.Sprintf("host:%s", MockGetHostname())}},
+}
+
+var FlattenKeyTests = []struct {
+	KeyToFlatten []string
+	Expected     string
+}{
+	{[]string{"a", "b", "c"}, "a.b.c"},
+	{[]string{"spaces must", "flatten", "to", "underscores"}, "spaces_must.flatten.to.underscores"},
+}
+
+var MetricSinkTests = []struct {
+	Method                string
+	Metric                []string
+	Value                 interface{}
+	Tags                  []string
+	EnableHostnameTagging bool
+	Expected              string
+}{
+	{"SetGauge", []string{"foo", "bar"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar:42.000000|g"},
+	{"SetGauge", []string{"foo", "bar", "baz"}, float32(42), EmptyTags, HostnameDisabled, "foo.bar.baz:42.000000|g"},
+	{"AddSample", []string{"sample", "thing"}, float32(4), EmptyTags, HostnameDisabled, "sample.thing:4.000000|ms"},
+	{"IncrCounter", []string{"count", "me"}, float32(3), EmptyTags, HostnameDisabled, "count.me:3|c"},
+
+	{"SetGauge", []string{"foo", "baz"}, float32(42), []string{"my_tag:my_value"}, HostnameDisabled, "foo.baz:42.000000|g|#my_tag:my_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []string{"my_tag:my_value", "other_tag:other_value"}, HostnameDisabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value"},
+	{"SetGauge", []string{"foo", "bar"}, float32(42), []string{"my_tag:my_value", "other_tag:other_value"}, HostnameEnabled, "foo.bar:42.000000|g|#my_tag:my_value,other_tag:other_value,host:test_hostname"},
+}
+
+func MockNewDogStatsdSink(addr string, tags []string, tagWithHostname bool) *DogStatsdSink {
+	dog, _ := NewDogStatsdSink(addr, tags, tagWithHostname)
+	dog.hostnameGetter = MockGetHostname
+	return dog
+}
+
+func TestParseKey(t *testing.T) {
+	for _, tt := range ParseKeyTests {
+		dog := MockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.EnableHostnameTagging)
+		key, tags := dog.parseKey(tt.KeyToParse)
+
+		if !reflect.DeepEqual(key, tt.ExpectedKey) {
+			t.Fatalf("Key Parsing failed for %v", tt.KeyToParse)
+		}
+
+		if !reflect.DeepEqual(tags, tt.ExpectedTags) {
+			t.Fatalf("Tag Parsing Failed for %v", tt.KeyToParse)
+		}
+	}
+}
+
+func TestFlattenKey(t *testing.T) {
+	dog := MockNewDogStatsdSink(DogStatsdAddr, EmptyTags, HostnameDisabled)
+	for _, tt := range FlattenKeyTests {
+		if !reflect.DeepEqual(dog.flattenKey(tt.KeyToFlatten), tt.Expected) {
+			t.Fatalf("Flattening %v failed", tt.KeyToFlatten)
+		}
+	}
+}
+
+func TestMetricSink(t *testing.T) {
+	udpAddr, err := net.ResolveUDPAddr("udp", DogStatsdAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server, err := net.ListenUDP("udp", udpAddr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.Close()
+
+	buf := make([]byte, 1024)
+
+	for _, tt := range MetricSinkTests {
+		dog := MockNewDogStatsdSink(DogStatsdAddr, tt.Tags, tt.EnableHostnameTagging)
+		method := reflect.ValueOf(dog).MethodByName(tt.Method)
+		method.Call([]reflect.Value{
+			reflect.ValueOf(tt.Metric),
+			reflect.ValueOf(tt.Value)})
+
+		n, _ := server.Read(buf)
+		msg := buf[:n]
+		if string(msg) != tt.Expected {
+			t.Fatalf("Line %s does not match expected: %s", string(msg), tt.Expected)
+		}
+	}
+}

--- a/start.go
+++ b/start.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"fmt"
 	"os"
 	"time"
 )
@@ -71,6 +72,14 @@ func NewGlobal(conf *Config, sink MetricSink) (*Metrics, error) {
 		globalMetrics = metrics
 	}
 	return metrics, err
+}
+
+// GetConfig returns the Config for the globalMetrics instance if available
+func GetConfig() (*Config, error) {
+	if globalMetrics != nil {
+		return &globalMetrics.Config, nil
+	}
+	return nil, fmt.Errorf("Global configuration not available!")
 }
 
 // Proxy all the methods to the globalMetrics instance


### PR DESCRIPTION
This adds a very basic DogStatsdSink implementing the MetricSink interface.
It has two main features:
1. Using the client at https://github.com/DataDog/datadog-go/statsd it allows global tags to be assigned to all metrics sent into the sink
2. When necessary, it splices out the hostname from incoming metric names, and delegates `host` tagging to the Dogstatsd server. This allows for much saner grouping by host in the Datadog backend.