### PR TITLE
datadog/dogstatsd: use the buffered writer

### DIFF
--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -17,8 +17,8 @@ type DogStatsdSink struct {
 }
 
 // NewDogStatsdSink is used to create a new DogStatsdSink with sane defaults
-func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
-	client, err := statsd.New(addr)
+func NewDogStatsdSink(addr string, hostName string, buflen int) (*DogStatsdSink, error) {
+	client, err := statsd.NewBuffered(addr, buflen)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This will prevent contention on writing metrics because without using
the buffered version each dogstatsd packet is written to synchronously
which requires acquiring a mutex.